### PR TITLE
WIP: Use patch library to generalize

### DIFF
--- a/partial-map.cabal
+++ b/partial-map.cabal
@@ -8,7 +8,7 @@ maintainer:          maintainer@obsidian.systems
 category:            Data
 stability:           Experimental
 build-type:          Simple
-cabal-version:       >=1.10
+cabal-version:       >= 1.10
 
 library
   exposed-modules:     Data.PartialMap
@@ -16,5 +16,6 @@ library
                      , base
                      , containers
                      , monoidal-containers
+                     , patch
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/patch-or-replace.cabal
+++ b/patch-or-replace.cabal
@@ -1,4 +1,4 @@
-name:                partial-map
+name:                patch-or-replace
 version:             0.1.0.0
 license:             BSD3
 license-file:        LICENSE
@@ -11,7 +11,7 @@ build-type:          Simple
 cabal-version:       >= 1.10
 
 library
-  exposed-modules:     Data.PartialMap
+  exposed-modules:     Data.Patch.OrReplace
   build-depends:       aeson
                      , base
                      , containers

--- a/src/Data/PartialMap.hs
+++ b/src/Data/PartialMap.hs
@@ -1,81 +1,103 @@
-{-# LANGUAGE DeriveFoldable #-}
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- The derived instances are undecidable in the case of a pathological instance like
+-- instance Patch x where
+--   type PatchTarget x = PatchOrReplace x
+{-# LANGUAGE UndecidableInstances #-}
+
 module Data.PartialMap where
 
-import Data.Aeson
+--import Data.Aeson
 import Data.Coerce
 import Data.Either
+import qualified Data.Map as Map
+import Data.Map (Map)
 import Data.Maybe
-import Data.Map.Monoidal as Map
 import Data.Monoid hiding ((<>), First (..))
+import Data.Patch
+import Data.Patch.Map
 import Data.Semigroup
-import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Set (Set)
 import GHC.Generics
 
-data PartialMap k v
-   = PartialMap_Complete (MonoidalMap k v)
-   | PartialMap_Partial (MonoidalMap k (First (Maybe v)))
-   deriving (Show, Read, Eq, Ord, Foldable, Functor, Generic)
+-- | A choice of either a patch or a replacement value.
+data PatchOrReplace p
+  = PatchOrReplace_Patch p
+  | PatchOrReplace_Complete (PatchTarget p)
+  deriving (Generic)
 
-isComplete :: PartialMap k v -> Bool
+type PartialMap k v = PatchOrReplace (PatchMap k v)
+
+isComplete :: PatchOrReplace p -> Bool
 isComplete = isJust . getComplete
 
-getComplete :: PartialMap k v -> Maybe (MonoidalMap k v)
+getComplete :: PatchOrReplace p -> Maybe (PatchTarget p)
 getComplete = \case
-  PartialMap_Complete m -> Just m
-  PartialMap_Partial _ -> Nothing
+  PatchOrReplace_Patch _ -> Nothing
+  PatchOrReplace_Complete m -> Just m
 
-knownKeysSet :: PartialMap k v -> Set k
+knownKeysSet :: PatchOrReplace (PatchMap k v) -> Set k
 knownKeysSet = \case
-  PartialMap_Complete x -> Map.keysSet x
-  PartialMap_Partial x -> Map.keysSet $ Map.mapMaybe getFirst x
+  PatchOrReplace_Complete x -> Map.keysSet x
+  PatchOrReplace_Patch x -> Map.keysSet $ Map.mapMaybe id $ unPatchMap x
+
+completePatchOrReplace :: PatchOrReplace p -> Maybe (PatchTarget p)
+completePatchOrReplace = \case
+  PatchOrReplace_Complete t -> Just t
+  PatchOrReplace_Patch _ -> Nothing
 
 knownKeys :: PartialMap k v -> [k]
 knownKeys = Set.toList . knownKeysSet
 
-knownSubMap :: PartialMap k v -> MonoidalMap k v
+knownSubMap :: PartialMap k v -> Map k v
 knownSubMap = \case
-  PartialMap_Complete m -> m
-  PartialMap_Partial m -> Map.mapMaybe getFirst m
+  PatchOrReplace_Complete m -> m
+  PatchOrReplace_Patch m -> Map.mapMaybe id $ unPatchMap m
 
-instance (Ord k) => Monoid (PartialMap k v) where
-  mempty = PartialMap_Partial mempty
-  mappend new old = case new of
-    PartialMap_Complete _ -> new
-    PartialMap_Partial p -> case old of
-      PartialMap_Partial oldp -> PartialMap_Partial $ p <> oldp
-      PartialMap_Complete oldc -> PartialMap_Complete $ applyMap (coerce p) (coerce oldc)
-      where
-        applyMap :: Ord k => MonoidalMap k (Maybe v) -> MonoidalMap k v -> MonoidalMap k v
-        applyMap patch old' = Map.unionWith const insertions (old' `Map.difference` deletions)
-          where (deletions, insertions) = mapPartitionEithers $ maybeToEither <$> patch
-                maybeToEither = \case
-                  Nothing -> Left ()
-                  Just r -> Right r
-        mapPartitionEithers :: MonoidalMap k (Either a b) -> (MonoidalMap k a, MonoidalMap k b)
-        mapPartitionEithers m = (fromLeft <$> ls, fromRight <$> rs)
-          where (ls, rs) = Map.partition isLeft m
-                fromLeft (Left l) = l
-                fromLeft _ = error "mapPartitionEithers: fromLeft received a Right value; this should be impossible"
-                fromRight (Right r) = r
-                fromRight _ = error "mapPartitionEithers: fromRight received a Left value; this should be impossible"
+deriving instance (Eq p, Eq (PatchTarget p)) => Eq (PatchOrReplace p)
+deriving instance (Ord p, Ord (PatchTarget p)) => Ord (PatchOrReplace p)
+deriving instance (Show p, Show (PatchTarget p)) => Show (PatchOrReplace p)
+deriving instance (Read p, Read (PatchTarget p)) => Read (PatchOrReplace p)
+-- instance (ToJSON p, ToJSON (PatchTarget p)) => ToJSON (PatchOrReplace p)
+-- instance (FromJSON p, FromJSON (PatchTarget p)) => FromJSON (PatchOrReplace p)
 
-instance (Ord k) => Semigroup (PartialMap k v) where
-  (<>) = mappend
+instance (Monoid p, Patch p) => Monoid (PatchOrReplace p) where
+  mempty = PatchOrReplace_Patch mempty
+  mappend = (<>)
 
-instance (ToJSONKey k, ToJSON v) => ToJSON (PartialMap k v)
-instance (Ord k, FromJSONKey k, FromJSON v) => FromJSON (PartialMap k v)
+instance (Semigroup p, Patch p) => Semigroup (PatchOrReplace p) where
+  (<>) = curry $ \case
+    (PatchOrReplace_Patch a, PatchOrReplace_Patch b) -> PatchOrReplace_Patch $ a <> b
+    (PatchOrReplace_Patch a, PatchOrReplace_Complete b) -> PatchOrReplace_Complete $ applyAlways a b
+    (PatchOrReplace_Complete a, _) -> PatchOrReplace_Complete a
+
+instance (PatchHet p) => PatchHet (PatchOrReplace p) where
+  type PatchTarget (PatchOrReplace p) = PatchTarget p
+  type PatchSource (PatchOrReplace p) = PatchSource p
+  applyHet p0 m = case p0 of
+    PatchOrReplace_Patch p -> applyHet p m
+    PatchOrReplace_Complete c -> Right c
+instance (Patch p) => Patch (PatchOrReplace p) where
+  apply p0 m = case p0 of
+    PatchOrReplace_Patch p -> apply p m
+    PatchOrReplace_Complete c -> Just c
+
+--instance (ToJSONKey k, ToJSON v) => ToJSON (PartialMap k v)
+--instance (Ord k, FromJSONKey k, FromJSON v) => FromJSON (PatchOrReplace (PatchMap k v))
 
 type PartialSet k = PartialMap k ()
 
 fromKnown :: Set k -> PartialSet k
-fromKnown = PartialMap_Partial . Map.fromSet (\_ -> First $ Just ())
+fromKnown = PatchOrReplace_Patch . PatchMap . Map.fromSet (\_ -> Just ())
 
-fromKnownAbsent :: Set k -> PartialMap k ()
-fromKnownAbsent = PartialMap_Partial . Map.fromSet (\_ -> First Nothing)
+fromKnownAbsent :: Set k -> PartialSet k
+fromKnownAbsent = PatchOrReplace_Patch . PatchMap . Map.fromSet (\_ -> Nothing)
 
-fromKnownComplete :: Set k -> PartialMap k ()
-fromKnownComplete = PartialMap_Complete . Map.fromSet (\_ -> ())
+fromKnownComplete :: Set k -> PartialSet k
+fromKnownComplete = PatchOrReplace_Complete . Map.fromSet (\_ -> ())

--- a/src/Data/Patch/OrReplace.hs
+++ b/src/Data/Patch/OrReplace.hs
@@ -10,7 +10,7 @@
 --   type PatchTarget x = PatchOrReplace x
 {-# LANGUAGE UndecidableInstances #-}
 
-module Data.PartialMap where
+module Data.Patch.OrReplace where
 
 --import Data.Aeson
 import Data.Coerce


### PR DESCRIPTION
WIP cause some aeson stuff went away, and don't use `MonoidalMap` anymore.